### PR TITLE
fix: correct network name in docker-compose configuration

### DIFF
--- a/.changeset/five-rats-slide.md
+++ b/.changeset/five-rats-slide.md
@@ -1,0 +1,5 @@
+---
+"@hexcuit/discord-bot": patch
+---
+
+docker fix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ services:
         max-file: "3"
 
 networks:
-  discord-bot-network:
+  hexcuit-discord-bot-network:
     driver: bridge


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance (Claude Code, GitHub Copilot, etc.),
  please disclose it in the PR description.
-->

<!--
  Thanks for submitting a Pull Request!
  Please provide enough information so that others can review your PR.
  Learn more about contributing: CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary. Example: Closes #123 -->

## Changes

<!-- Describe the specific changes made in this PR -->

- 
- 
- 

## Test Plan

<!-- How did you verify that your implementation is correct? -->

- [ ] Type check passed: `bun run typecheck`
- [ ] Manual testing completed: <!-- describe your testing -->

## Related Issues

<!-- Link any related issues here. Example: Closes #123, Relates to #456 -->

## Notes

<!-- Any additional context, screenshots, or information that reviewers should know -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker networking configuration, renaming networks to use a standardized naming convention across the deployment setup
  * Prepared patch release documenting Docker-related updates to the Discord bot package

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->