### PR TITLE
feat: add /recruit command for custom game recruitment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@hexcuit/discord-bot",
       "dependencies": {
-        "@hexcuit/server": "0.1.12",
+        "@hexcuit/server": "^0.2.0",
         "discord.js": "14.25.0",
       },
       "devDependencies": {
@@ -89,7 +89,7 @@
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
-    "@hexcuit/server": ["@hexcuit/server@0.1.12", "", { "dependencies": { "hono": "4.10.6" } }, "sha512-tQ7qbW14uGk4rh9r9OyyvPYsgU+oSfcesAtoqKaBfVFwA8ngBdsfs0iJWZOBPzAgMUf20yICyhvYA38mTaU7iQ=="],
+    "@hexcuit/server": ["@hexcuit/server@0.2.0", "", { "dependencies": { "hono": "4.10.6" } }, "sha512-+TGisszpNmF5PdOXIArc15cfm2xiKGiTw6QuWI47wXkdLjpAQv2+oYGohjXF+TILzbvwjxuxq/F/CMO1SzYaUw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"version": "changeset version && bun i --lockfile-only"
 	},
 	"dependencies": {
-		"@hexcuit/server": "0.1.12",
+		"@hexcuit/server": "0.2.0",
 		"discord.js": "14.25.0"
 	},
 	"devDependencies": {

--- a/src/commands/recruit/index.ts
+++ b/src/commands/recruit/index.ts
@@ -3,6 +3,7 @@ import {
 	ButtonBuilder,
 	ButtonStyle,
 	EmbedBuilder,
+	InteractionContextType,
 	MessageFlags,
 	SlashCommandBuilder,
 } from 'discord.js'
@@ -102,6 +103,7 @@ export default {
 	command: new SlashCommandBuilder()
 		.setName('recruit')
 		.setDescription('カスタムゲームの募集を作成します（定員10人）')
+		.setContexts(InteractionContextType.Guild)
 		.addBooleanOption((option) =>
 			option.setName('anonymous').setDescription('匿名モード（参加者名を非表示にし、人数のみ表示）').setRequired(false),
 		)
@@ -115,11 +117,12 @@ export default {
 		const recruitmentId = crypto.randomUUID()
 
 		const embed = createEmbed(anonymous, [], CAPACITY, interaction.user.id, startTime)
-		const buttons = createButtons(recruitmentId, false)
+		const disabledButtons = createButtons(recruitmentId, true)
 
+		// 最初はボタンを無効化して送信（API完了前のクリックを防止）
 		await interaction.reply({
 			embeds: [embed],
-			components: [buttons],
+			components: [disabledButtons],
 		})
 
 		const reply = await interaction.fetchReply()
@@ -144,7 +147,15 @@ export default {
 					embeds: [],
 					components: [],
 				})
+				return
 			}
+
+			// API成功後にボタンを有効化
+			const enabledButtons = createButtons(recruitmentId, false)
+			await interaction.editReply({
+				embeds: [embed],
+				components: [enabledButtons],
+			})
 		} catch (error) {
 			logger.error('募集作成エラー:', error)
 			await interaction.editReply({
@@ -204,6 +215,16 @@ export default {
 				const recruitResponse = await apiClient.recruit[':id'].$get({
 					param: { id: recruitmentId },
 				})
+
+				if (!recruitResponse.ok) {
+					logger.error('募集情報取得失敗:', recruitResponse.status)
+					await interaction.reply({
+						content: '募集情報の取得に失敗しました。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
 				const recruitData = (await recruitResponse.json()) as {
 					recruitment: {
 						anonymous: string
@@ -211,6 +232,8 @@ export default {
 						startTime: string | null
 					}
 				}
+
+				const isAnonymous = recruitData.recruitment.anonymous === 'true'
 
 				if (data.isFull) {
 					const fullEmbed = createFullEmbed(
@@ -229,7 +252,7 @@ export default {
 					})
 				} else {
 					const embed = createEmbed(
-						recruitData.recruitment.anonymous === 'true',
+						isAnonymous,
 						data.participants,
 						CAPACITY,
 						recruitData.recruitment.creatorId,
@@ -270,6 +293,16 @@ export default {
 				const recruitResponse = await apiClient.recruit[':id'].$get({
 					param: { id: recruitmentId },
 				})
+
+				if (!recruitResponse.ok) {
+					logger.error('募集情報取得失敗:', recruitResponse.status)
+					await interaction.reply({
+						content: '募集情報の取得に失敗しました。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
 				const recruitData = (await recruitResponse.json()) as {
 					recruitment: {
 						anonymous: string
@@ -278,8 +311,10 @@ export default {
 					}
 				}
 
+				const isAnonymous = recruitData.recruitment.anonymous === 'true'
+
 				const embed = createEmbed(
-					recruitData.recruitment.anonymous === 'true',
+					isAnonymous,
 					data.participants,
 					CAPACITY,
 					recruitData.recruitment.creatorId,

--- a/src/commands/recruit/index.ts
+++ b/src/commands/recruit/index.ts
@@ -1,0 +1,303 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+	MessageFlags,
+	SlashCommandBuilder,
+} from 'discord.js'
+import { colors } from '@/config'
+import { logger } from '@/lib/logger'
+import type { Command } from '@/types/command'
+import { apiClient } from '@/utils/api-client'
+
+const CAPACITY = 10
+
+const parseCustomId = (customId: string) => {
+	const parts = customId.split(':')
+	return {
+		command: parts[0],
+		action: parts[1],
+		recruitmentId: parts[2],
+	}
+}
+
+const createEmbed = (
+	anonymous: boolean,
+	participants: string[],
+	capacity: number,
+	creatorId: string,
+	startTime?: string | null,
+) => {
+	const embed = new EmbedBuilder().setTitle('カスタム募集').setColor(colors.success)
+
+	if (startTime) {
+		embed.addFields({
+			name: '開始時間',
+			value: startTime,
+			inline: true,
+		})
+	}
+
+	if (anonymous) {
+		embed.addFields({
+			name: '参加者',
+			value: `${participants.length}/${capacity}人`,
+			inline: false,
+		})
+	} else {
+		const participantList = participants.length > 0 ? participants.map((id) => `<@${id}>`).join('\n') : 'なし'
+
+		embed.addFields({
+			name: `参加者 (${participants.length}/${capacity})`,
+			value: participantList,
+			inline: false,
+		})
+	}
+
+	embed.setFooter({ text: `主催: ${creatorId}` })
+
+	return embed
+}
+
+const createButtons = (recruitmentId: string, disabled: boolean) => {
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder()
+			.setCustomId(`recruit:join:${recruitmentId}`)
+			.setLabel('参加')
+			.setStyle(ButtonStyle.Success)
+			.setDisabled(disabled),
+		new ButtonBuilder()
+			.setCustomId(`recruit:leave:${recruitmentId}`)
+			.setLabel('キャンセル')
+			.setStyle(ButtonStyle.Danger)
+			.setDisabled(disabled),
+	)
+}
+
+const createFullEmbed = (participants: string[], creatorId: string, startTime?: string | null) => {
+	const embed = new EmbedBuilder().setTitle('募集完了!').setDescription('定員に達しました!').setColor(colors.success)
+
+	if (startTime) {
+		embed.addFields({
+			name: '開始時間',
+			value: startTime,
+			inline: true,
+		})
+	}
+
+	const mentions = participants.map((id) => `<@${id}>`).join('\n')
+	embed.addFields({
+		name: `参加者 (${participants.length}/${CAPACITY})`,
+		value: mentions,
+		inline: false,
+	})
+
+	embed.setFooter({ text: `主催: ${creatorId}` })
+
+	return embed
+}
+
+export default {
+	command: new SlashCommandBuilder()
+		.setName('recruit')
+		.setDescription('カスタムゲームの募集を作成します（定員10人）')
+		.addBooleanOption((option) =>
+			option.setName('anonymous').setDescription('匿名モード（参加者名を非表示にし、人数のみ表示）').setRequired(false),
+		)
+		.addStringOption((option) =>
+			option.setName('start_time').setDescription('開始時間（例: 21:00）').setRequired(false),
+		),
+
+	execute: async (interaction) => {
+		const anonymous = interaction.options.getBoolean('anonymous') ?? false
+		const startTime = interaction.options.getString('start_time')
+		const recruitmentId = crypto.randomUUID()
+
+		const embed = createEmbed(anonymous, [], CAPACITY, interaction.user.id, startTime)
+		const buttons = createButtons(recruitmentId, false)
+
+		await interaction.reply({
+			embeds: [embed],
+			components: [buttons],
+		})
+
+		const reply = await interaction.fetchReply()
+
+		try {
+			const response = await apiClient.recruit.$post({
+				json: {
+					id: recruitmentId,
+					guildId: interaction.guildId!,
+					channelId: interaction.channelId,
+					messageId: reply.id,
+					creatorId: interaction.user.id,
+					anonymous,
+					startTime: startTime || undefined,
+				},
+			})
+
+			if (!response.ok) {
+				logger.error('募集作成失敗:', response.status)
+				await interaction.editReply({
+					content: '募集の作成に失敗しました。',
+					embeds: [],
+					components: [],
+				})
+			}
+		} catch (error) {
+			logger.error('募集作成エラー:', error)
+			await interaction.editReply({
+				content: '募集の作成に失敗しました。',
+				embeds: [],
+				components: [],
+			})
+		}
+	},
+
+	button: async (interaction) => {
+		const { action, recruitmentId } = parseCustomId(interaction.customId)
+
+		if (!recruitmentId) {
+			await interaction.reply({
+				content: '無効な操作です。',
+				flags: MessageFlags.Ephemeral,
+			})
+			return
+		}
+
+		try {
+			if (action === 'join') {
+				const response = await apiClient.recruit.join.$post({
+					json: {
+						recruitmentId,
+						discordId: interaction.user.id,
+					},
+				})
+
+				if (!response.ok) {
+					const error = (await response.json()) as { error?: string }
+					const message =
+						error.error === 'Already joined'
+							? '既に参加しています。'
+							: error.error === 'Recruitment is full'
+								? '定員に達しています。'
+								: error.error === 'Recruitment is not open'
+									? '募集は終了しています。'
+									: '参加に失敗しました。'
+
+					await interaction.reply({
+						content: message,
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				const data = (await response.json()) as {
+					success: boolean
+					isFull: boolean
+					count: number
+					participants: string[]
+				}
+
+				// 募集情報取得
+				const recruitResponse = await apiClient.recruit[':id'].$get({
+					param: { id: recruitmentId },
+				})
+				const recruitData = (await recruitResponse.json()) as {
+					recruitment: {
+						anonymous: string
+						creatorId: string
+						startTime: string | null
+					}
+				}
+
+				if (data.isFull) {
+					const fullEmbed = createFullEmbed(
+						data.participants,
+						recruitData.recruitment.creatorId,
+						recruitData.recruitment.startTime,
+					)
+					await interaction.update({
+						embeds: [fullEmbed],
+						components: [],
+					})
+
+					const mentions = data.participants.map((id: string) => `<@${id}>`).join(' ')
+					await interaction.followUp({
+						content: `募集完了! ${mentions}`,
+					})
+				} else {
+					const embed = createEmbed(
+						recruitData.recruitment.anonymous === 'true',
+						data.participants,
+						CAPACITY,
+						recruitData.recruitment.creatorId,
+						recruitData.recruitment.startTime,
+					)
+					const buttons = createButtons(recruitmentId, false)
+
+					await interaction.update({
+						embeds: [embed],
+						components: [buttons],
+					})
+				}
+			} else if (action === 'leave') {
+				const response = await apiClient.recruit.leave.$post({
+					json: {
+						recruitmentId,
+						discordId: interaction.user.id,
+					},
+				})
+
+				if (!response.ok) {
+					const error = (await response.json()) as { error?: string }
+					const message = error.error === 'Not joined' ? '参加していません。' : 'キャンセルに失敗しました。'
+
+					await interaction.reply({
+						content: message,
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				const data = (await response.json()) as {
+					success: boolean
+					count: number
+					participants: string[]
+				}
+
+				const recruitResponse = await apiClient.recruit[':id'].$get({
+					param: { id: recruitmentId },
+				})
+				const recruitData = (await recruitResponse.json()) as {
+					recruitment: {
+						anonymous: string
+						creatorId: string
+						startTime: string | null
+					}
+				}
+
+				const embed = createEmbed(
+					recruitData.recruitment.anonymous === 'true',
+					data.participants,
+					CAPACITY,
+					recruitData.recruitment.creatorId,
+					recruitData.recruitment.startTime,
+				)
+				const buttons = createButtons(recruitmentId, false)
+
+				await interaction.update({
+					embeds: [embed],
+					components: [buttons],
+				})
+			}
+		} catch (error) {
+			logger.error('ボタン処理エラー:', error)
+			await interaction.reply({
+				content: '処理中にエラーが発生しました。',
+				flags: MessageFlags.Ephemeral,
+			})
+		}
+	},
+} satisfies Command

--- a/src/events/interaction-create/button.ts
+++ b/src/events/interaction-create/button.ts
@@ -2,7 +2,12 @@ import type { ButtonInteraction, CacheType } from 'discord.js'
 import { logger } from '@/lib/logger'
 
 export const handleButton = (interaction: ButtonInteraction<CacheType>) => {
-	const command = interaction.client.commands.get(interaction.customId)
+	// customIdをパース: "commandName" または "commandName:action:data"
+	const [commandName] = interaction.customId.split(':')
+	if (!commandName) {
+		return
+	}
+	const command = interaction.client.commands.get(commandName)
 	if (!command) {
 		return
 	}


### PR DESCRIPTION
## Summary
- `/recruit` スラッシュコマンドを追加（カスタムゲーム募集機能）
- ボタンハンドラーを更新（customId形式: `commandName:action:data`）
- `@hexcuit/server` を 0.2.0 に更新

## 機能
| 項目 | 内容 |
|------|------|
| 定員 | 10人 |
| 通常モード | 参加者リスト表示 |
| 匿名モード | 人数のみ表示（3/10人） |
| 集合通知 | 10人集まったら全員メンション |
| 操作 | 参加/キャンセルボタン |

## オプション
- `anonymous` - 匿名募集（参加者名を非表示）
- `start_time` - 開始時刻（任意）

## Test plan
- [ ] `/recruit` コマンドで募集作成
- [ ] 参加ボタンで参加
- [ ] キャンセルボタンでキャンセル
- [ ] 匿名モードで人数のみ表示
- [ ] 10人集まったらメンション

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New recruitment command for Discord with anonymous mode, customizable start times, and interactive join/leave buttons that update in real time.

* **Bug Fixes**
  * Improved button interaction handling so button presses reliably route to the correct command and provide clearer feedback on errors.

* **Chores**
  * Updated server dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->