### PR TITLE
feat(recruit): 強制開始ボタンを追加

### DIFF
--- a/src/commands/recruit/index.ts
+++ b/src/commands/recruit/index.ts
@@ -80,6 +80,11 @@ const createButtons = (recruitmentId: string, disabled: boolean) => {
 			.setStyle(ButtonStyle.Danger)
 			.setDisabled(disabled),
 		new ButtonBuilder()
+			.setCustomId(`recruit:force_start:${recruitmentId}`)
+			.setLabel('強制開始')
+			.setStyle(ButtonStyle.Primary)
+			.setDisabled(disabled),
+		new ButtonBuilder()
 			.setCustomId(`recruit:close:${recruitmentId}`)
 			.setLabel('募集終了')
 			.setStyle(ButtonStyle.Secondary)
@@ -467,6 +472,90 @@ export default {
 				await interaction.update({
 					embeds: [embed],
 					components: [buttons],
+				})
+			} else if (action === 'force_start') {
+				// 募集情報取得
+				const recruitResponse = await apiClient.recruit[':id'].$get({
+					param: { id: recruitmentId },
+				})
+
+				if (!recruitResponse.ok) {
+					logger.error('募集情報取得失敗:', recruitResponse.status)
+					await interaction.reply({
+						content: '募集情報の取得に失敗しました。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				const recruitData = (await recruitResponse.json()) as {
+					recruitment: {
+						anonymous: string
+						creatorId: string
+						startTime: string | null
+						status: string
+					}
+					participants: { discordId: string }[]
+				}
+
+				// 主催者チェック
+				if (recruitData.recruitment.creatorId !== interaction.user.id) {
+					await interaction.reply({
+						content: '強制開始できるのは主催者のみです。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				// 既に終了済みチェック
+				if (recruitData.recruitment.status === 'closed') {
+					await interaction.reply({
+						content: 'この募集は既に終了しています。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				// 参加者がいない場合
+				if (recruitData.participants.length === 0) {
+					await interaction.reply({
+						content: '参加者がいないため開始できません。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				// 募集終了API呼び出し（物理削除）
+				const closeResponse = await apiClient.recruit[':id'].$delete({
+					param: { id: recruitmentId },
+				})
+
+				if (!closeResponse.ok) {
+					logger.error('募集終了失敗:', closeResponse.status)
+					await interaction.reply({
+						content: '強制開始に失敗しました。',
+						flags: MessageFlags.Ephemeral,
+					})
+					return
+				}
+
+				const participants = recruitData.participants.map((p) => p.discordId)
+
+				const fullEmbed = createFullEmbed(
+					participants,
+					recruitData.recruitment.creatorId,
+					recruitData.recruitment.startTime,
+					existingDescription,
+				)
+
+				await interaction.update({
+					embeds: [fullEmbed],
+					components: [],
+				})
+
+				const mentions = participants.map((id: string) => `<@${id}>`).join(' ')
+				await interaction.followUp({
+					content: `強制開始! ${mentions}`,
 				})
 			} else if (action === 'close') {
 				// 募集情報取得


### PR DESCRIPTION
## Summary
- 募集が定員に満たない場合でも主催者が開始できる「強制開始」ボタンを追加
- 主催者のみが実行可能、参加者が1人以上必要
- 開始時に参加者全員にメンション通知

## Test plan
- [ ] 募集を作成し、強制開始ボタンが表示されることを確認
- [ ] 主催者以外が強制開始を押すとエラーメッセージが表示されることを確認
- [ ] 参加者0人で強制開始を押すとエラーメッセージが表示されることを確認
- [ ] 参加者がいる状態で強制開始を押すと募集が終了し、参加者にメンションされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a force_start button to the recruitment interface enabling hosts to activate recruitment with automatic participant notifications and validation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->