### PR TITLE
feat: Phase 3 - ランク戦チーム分け・投票・/rank server実装

### DIFF
--- a/.changeset/phase3-ranked-match.md
+++ b/.changeset/phase3-ranked-match.md
@@ -1,0 +1,11 @@
+---
+"@hexcuit/discord-bot": minor
+---
+
+Phase 3: ランク戦チーム分け・勝敗投票・/rank serverコマンド追加
+
+- ランク戦募集完了時の自動チーム分け（Eloバランス）
+- 勝敗投票UI（Blue/Red投票ボタン）
+- 6票以上で試合確定・レート更新
+- `/rank server [@user]` - サーバー内ランク表示
+- `/rank leaderboard [limit]` - サーバーランキング表示

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@hexcuit/discord-bot",
       "dependencies": {
-        "@hexcuit/server": "0.6.0",
+        "@hexcuit/server": "0.7.0",
         "discord.js": "14.25.1",
       },
       "devDependencies": {
@@ -89,7 +89,7 @@
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
-    "@hexcuit/server": ["@hexcuit/server@0.6.0", "", { "dependencies": { "hono": "4.10.8" } }, "sha512-uIyNCWUCCsrW1X7+lalcJUui/LP4MYdgoEo34bgQF94BsEJBGypSyDXoEoTzq2w0/xJ13DhDkoE4z8IwvJuPxQ=="],
+    "@hexcuit/server": ["@hexcuit/server@0.7.0", "", { "dependencies": { "hono": "4.10.8" } }, "sha512-e3WVTB5Ct1fWLPyUONMxktiayDj7vsPdhKwdZGoMeaFZ6Gk3tUobWlFBnINp6nHCc2z7xtcuJOPFZ1YZPXAuGw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"version": "changeset version && bun i --lockfile-only"
 	},
 	"dependencies": {
-		"@hexcuit/server": "0.6.0",
+		"@hexcuit/server": "0.7.0",
 		"discord.js": "14.25.1"
 	},
 	"devDependencies": {

--- a/src/commands/rank/index.ts
+++ b/src/commands/rank/index.ts
@@ -1,0 +1,223 @@
+import { EmbedBuilder, InteractionContextType, MessageFlags, SlashCommandBuilder } from 'discord.js'
+import { colors } from '@/config'
+import { logger } from '@/lib/logger'
+import type { Command } from '@/types/command'
+import { apiClient } from '@/utils/api-client'
+
+export default {
+	command: new SlashCommandBuilder()
+		.setName('rank')
+		.setDescription('サーバー内ランク情報を表示します')
+		.setContexts(InteractionContextType.Guild)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('server')
+				.setDescription('サーバー内ランクを表示')
+				.addUserOption((option) =>
+					option.setName('user').setDescription('確認したいユーザー（指定しない場合は自分）').setRequired(false),
+				),
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('leaderboard')
+				.setDescription('サーバー内ランキングを表示')
+				.addIntegerOption((option) =>
+					option
+						.setName('limit')
+						.setDescription('表示人数（デフォルト: 10）')
+						.setRequired(false)
+						.setMinValue(1)
+						.setMaxValue(25),
+				),
+		),
+
+	execute: async (interaction) => {
+		if (!interaction.guildId) {
+			await interaction.reply({
+				content: 'このコマンドはサーバー内でのみ使用できます。',
+				flags: MessageFlags.Ephemeral,
+			})
+			return
+		}
+
+		const subcommand = interaction.options.getSubcommand()
+
+		switch (subcommand) {
+			case 'server':
+				await executeServer(interaction)
+				break
+			case 'leaderboard':
+				await executeLeaderboard(interaction)
+				break
+		}
+	},
+} satisfies Command
+
+type RatingData = {
+	discordId: string
+	guildId: string
+	rating: number | null
+	wins: number | null
+	losses: number | null
+	placementGames: number | null
+	isPlacement: boolean | null
+	rank: string | null
+	rankDetail: {
+		tier: string
+		division: string | null
+		lp: number
+	} | null
+}
+
+const executeServer = async (interaction: Parameters<Command['execute']>[0]) => {
+	await interaction.deferReply()
+
+	const targetUser = interaction.options.getUser('user') ?? interaction.user
+	const guildId = interaction.guildId as string
+
+	try {
+		// レーティング取得
+		const response = await apiClient.guild.rating.$get({
+			query: { guildId, discordIds: [targetUser.id] },
+		})
+
+		if (!response.ok) {
+			logger.error('レーティング取得失敗:', response.status)
+			await interaction.editReply({
+				content: 'ランク情報の取得に失敗しました。',
+			})
+			return
+		}
+
+		const data = (await response.json()) as { ratings: RatingData[] }
+		const rating = data.ratings[0]
+
+		if (!rating || rating.rating === null) {
+			await interaction.editReply({
+				content: `<@${targetUser.id}> はまだランク戦に参加していません。`,
+			})
+			return
+		}
+
+		// ランキング内での順位を取得
+		const rankingResponse = await apiClient.guild.ranking.$get({
+			query: { guildId, limit: '100' },
+		})
+
+		let position: number | null = null
+		if (rankingResponse.ok) {
+			const rankingData = (await rankingResponse.json()) as {
+				rankings: Array<{ discordId: string; position: number }>
+			}
+			const userRanking = rankingData.rankings.find((r) => r.discordId === targetUser.id)
+			position = userRanking?.position ?? null
+		}
+
+		const wins = rating.wins ?? 0
+		const losses = rating.losses ?? 0
+		const totalGames = wins + losses
+		const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0
+
+		const embed = new EmbedBuilder()
+			.setTitle(`🏆 ${targetUser.displayName} のサーバーランク`)
+			.setThumbnail(targetUser.displayAvatarURL())
+			.setColor(colors.primary)
+
+		if (rating.isPlacement) {
+			const placementGames = rating.placementGames ?? 0
+			embed.setDescription(`プレイスメント中: ${placementGames}/5 試合`)
+			embed.addFields(
+				{ name: 'レート', value: `${rating.rating}`, inline: true },
+				{ name: '戦績', value: `${wins}勝 ${losses}敗`, inline: true },
+				{ name: '勝率', value: `${winRate}%`, inline: true },
+			)
+		} else {
+			embed.addFields(
+				{ name: 'ランク', value: rating.rank ?? 'Unknown', inline: true },
+				{ name: 'レート', value: `${rating.rating}`, inline: true },
+				{ name: '順位', value: position ? `#${position}` : '-', inline: true },
+				{ name: '戦績', value: `${wins}勝 ${losses}敗`, inline: true },
+				{ name: '勝率', value: `${winRate}%`, inline: true },
+			)
+		}
+
+		await interaction.editReply({ embeds: [embed] })
+	} catch (error) {
+		logger.error('ランク取得エラー:', error)
+		await interaction.editReply({
+			content: 'ランク情報の取得中にエラーが発生しました。',
+		})
+	}
+}
+
+const executeLeaderboard = async (interaction: Parameters<Command['execute']>[0]) => {
+	await interaction.deferReply()
+
+	const guildId = interaction.guildId as string
+	const limit = interaction.options.getInteger('limit') ?? 10
+
+	try {
+		const response = await apiClient.guild.ranking.$get({
+			query: { guildId, limit: limit.toString() },
+		})
+
+		if (!response.ok) {
+			logger.error('ランキング取得失敗:', response.status)
+			await interaction.editReply({
+				content: 'ランキングの取得に失敗しました。',
+			})
+			return
+		}
+
+		const data = (await response.json()) as {
+			guildId: string
+			rankings: Array<{
+				position: number
+				discordId: string
+				rating: number
+				wins: number
+				losses: number
+				winRate: number
+				rank: string
+			}>
+		}
+
+		if (data.rankings.length === 0) {
+			await interaction.editReply({
+				content: 'まだランキングに登録されているプレイヤーがいません。',
+			})
+			return
+		}
+
+		const getMedal = (pos: number) => {
+			switch (pos) {
+				case 1:
+					return '🥇'
+				case 2:
+					return '🥈'
+				case 3:
+					return '🥉'
+				default:
+					return `${pos}.`
+			}
+		}
+
+		const rankingLines = data.rankings.map((r) => {
+			const medal = getMedal(r.position)
+			return `${medal} <@${r.discordId}> - ${r.rank} (${r.rating}) | ${r.wins}W ${r.losses}L (${r.winRate}%)`
+		})
+
+		const embed = new EmbedBuilder()
+			.setTitle('🏆 サーバーランキング')
+			.setDescription(rankingLines.join('\n'))
+			.setColor(colors.primary)
+			.setFooter({ text: `上位${data.rankings.length}人を表示` })
+
+		await interaction.editReply({ embeds: [embed] })
+	} catch (error) {
+		logger.error('ランキング取得エラー:', error)
+		await interaction.editReply({
+			content: 'ランキングの取得中にエラーが発生しました。',
+		})
+	}
+}

--- a/src/commands/recruit/button.ts
+++ b/src/commands/recruit/button.ts
@@ -4,19 +4,27 @@ import { colors } from '@/config'
 import { logger } from '@/lib/logger'
 import { apiClient } from '@/utils/api-client'
 import {
+	balanceTeamsByElo,
 	CAPACITY,
 	createButtons,
 	createClosedEmbed,
 	createEmbed,
 	createFullEmbed,
+	createMatchEmbed,
+	createMatchResultEmbed,
 	createRankedButtons,
 	createRankedEmbed,
 	createRoleSelectMenu,
+	createVoteButtons,
 	formatRole,
 	type LolRole,
 	type Participant,
 	parseCustomId,
+	type TeamAssignments,
 } from './shared'
+
+// 初期レーティング
+const INITIAL_RATING = 1500
 
 export const handleButton = async (interaction: ButtonInteraction<CacheType>) => {
 	const { action, recruitmentId } = parseCustomId(interaction.customId)
@@ -58,6 +66,15 @@ export const handleButton = async (interaction: ButtonInteraction<CacheType>) =>
 				break
 			case 'rank_force':
 				await handleRankForce(interaction, recruitmentId, existingDescription)
+				break
+			case 'vote_blue':
+				await handleVote(interaction, recruitmentId, 'blue')
+				break
+			case 'vote_red':
+				await handleVote(interaction, recruitmentId, 'red')
+				break
+			case 'vote_cancel':
+				await handleVoteCancel(interaction, recruitmentId)
 				break
 		}
 	} catch (error) {
@@ -502,12 +519,71 @@ const handleConfirmRankJoin = async (
 		components: [buttons],
 	})
 
-	// 10人揃ったら自動でチーム分け
-	if (data.isFull) {
-		const mentions = data.participants.map((p) => `<@${p.discordId}>`).join(' ')
-		await interaction.followUp({
-			content: `🏆 ランク戦募集完了！ ${mentions}\n\n/team balance でチーム分けを行ってください。`,
+	// 10人揃ったら自動でチーム分け＆試合作成
+	if (data.isFull && interaction.guildId) {
+		// 募集終了
+		await apiClient.recruit[':id'].$delete({
+			param: { id: recruitmentId },
 		})
+
+		// チーム分け＆試合作成（別メッセージで）
+		const matchId = crypto.randomUUID()
+
+		// レーティング取得
+		const discordIds = data.participants.map((p) => p.discordId)
+		const ratingsResponse = await apiClient.guild.rating.$get({
+			query: { guildId: interaction.guildId, discordIds },
+		})
+
+		type RatingResponse = {
+			ratings: Array<{
+				discordId: string
+				rating: number | null
+			}>
+		}
+
+		let ratings: RatingResponse['ratings'] = []
+		if (ratingsResponse.ok) {
+			const ratingsData = (await ratingsResponse.json()) as RatingResponse
+			ratings = ratingsData.ratings
+		}
+
+		// レーティングを参加者にマッピング
+		const participantsWithRating = data.participants.map((p) => {
+			const ratingInfo = ratings.find((r) => r.discordId === p.discordId)
+			return {
+				discordId: p.discordId,
+				mainRole: p.mainRole as LolRole | null,
+				subRole: p.subRole as LolRole | null,
+				rating: ratingInfo?.rating ?? INITIAL_RATING,
+			}
+		})
+
+		// チームバランス
+		const teamAssignments = balanceTeamsByElo(participantsWithRating)
+
+		// 試合作成API呼び出し
+		const matchResponse = await apiClient.guild.match.$post({
+			json: {
+				id: matchId,
+				guildId: interaction.guildId,
+				channelId: interaction.channelId,
+				messageId: interaction.message.id,
+				teamAssignments,
+			},
+		})
+
+		if (matchResponse.ok) {
+			const matchEmbed = createMatchEmbed(teamAssignments, 0, 0, 6)
+			const voteButtons = createVoteButtons(matchId)
+
+			const mentions = data.participants.map((p) => `<@${p.discordId}>`).join(' ')
+			await interaction.followUp({
+				content: `🏆 ランク戦募集完了！チーム分けが完了しました！ ${mentions}\n\n試合終了後、勝利チームを投票してください。`,
+				embeds: [matchEmbed],
+				components: [voteButtons],
+			})
+		}
 	}
 }
 
@@ -579,7 +655,7 @@ const handleRankLeave = async (
 const handleRankForce = async (
 	interaction: ButtonInteraction<CacheType>,
 	recruitmentId: string,
-	existingDescription: string | null,
+	_existingDescription: string | null,
 ) => {
 	// ランク戦強制開始
 	const recruitResponse = await apiClient.recruit[':id'].$get({
@@ -597,6 +673,7 @@ const handleRankForce = async (
 
 	const recruitData = (await recruitResponse.json()) as {
 		recruitment: {
+			guildId: string
 			creatorId: string
 			startTime: string | null
 			status: string
@@ -643,32 +720,251 @@ const handleRankForce = async (
 		return
 	}
 
-	const embed = new EmbedBuilder()
-		.setTitle('🏆 ランク戦開始！')
-		.setDescription(existingDescription)
-		.setColor(colors.success)
+	// チーム分け＆試合作成
+	await startRankedMatch(interaction, recruitData.recruitment.guildId, recruitData.participants)
+}
 
-	const participantList = recruitData.participants
-		.map((p) => {
-			const mainRole = formatRole(p.mainRole as LolRole | null)
-			const subRole = formatRole(p.subRole as LolRole | null)
-			return `<@${p.discordId}> - メイン: ${mainRole} / サブ: ${subRole}`
-		})
-		.join('\n')
-
-	embed.addFields({
-		name: `参加者 (${recruitData.participants.length}人)`,
-		value: participantList,
-		inline: false,
+// ランク戦試合開始（チーム分け＆投票開始）
+const startRankedMatch = async (
+	interaction: ButtonInteraction<CacheType>,
+	guildId: string,
+	participants: Participant[],
+) => {
+	// 参加者のレーティングを取得
+	const discordIds = participants.map((p) => p.discordId)
+	const ratingsResponse = await apiClient.guild.rating.$get({
+		query: { guildId, discordIds },
 	})
+
+	type RatingResponse = {
+		ratings: Array<{
+			discordId: string
+			rating: number | null
+		}>
+	}
+
+	let ratings: RatingResponse['ratings'] = []
+	if (ratingsResponse.ok) {
+		const data = (await ratingsResponse.json()) as RatingResponse
+		ratings = data.ratings
+	}
+
+	// レーティングを参加者にマッピング（未登録は初期値1500）
+	const participantsWithRating = participants.map((p) => {
+		const ratingInfo = ratings.find((r) => r.discordId === p.discordId)
+		return {
+			discordId: p.discordId,
+			mainRole: p.mainRole as LolRole | null,
+			subRole: p.subRole as LolRole | null,
+			rating: ratingInfo?.rating ?? INITIAL_RATING,
+		}
+	})
+
+	// チームバランス
+	const teamAssignments = balanceTeamsByElo(participantsWithRating)
+
+	// 試合ID生成
+	const matchId = crypto.randomUUID()
+
+	// 試合作成API呼び出し
+	const matchResponse = await apiClient.guild.match.$post({
+		json: {
+			id: matchId,
+			guildId,
+			channelId: interaction.channelId,
+			messageId: interaction.message.id,
+			teamAssignments,
+		},
+	})
+
+	if (!matchResponse.ok) {
+		logger.error('試合作成失敗:', matchResponse.status)
+		await interaction.update({
+			content: '試合の作成に失敗しました。',
+			embeds: [],
+			components: [],
+		})
+		return
+	}
+
+	// 投票UI表示
+	const embed = createMatchEmbed(teamAssignments, 0, 0, 6)
+	const buttons = createVoteButtons(matchId)
+
+	await interaction.update({
+		embeds: [embed],
+		components: [buttons],
+	})
+
+	const mentions = participants.map((p) => `<@${p.discordId}>`).join(' ')
+	await interaction.followUp({
+		content: `🏆 チーム分けが完了しました！ ${mentions}\n\n試合終了後、勝利チームを投票してください。`,
+	})
+}
+
+// 投票ハンドラー
+const handleVote = async (interaction: ButtonInteraction<CacheType>, matchId: string, vote: 'blue' | 'red') => {
+	// 投票API呼び出し
+	const response = await apiClient.guild.match[':id'].vote.$post({
+		param: { id: matchId },
+		json: {
+			discordId: interaction.user.id,
+			vote,
+		},
+	})
+
+	if (!response.ok) {
+		const error = (await response.json()) as { error?: string }
+		const message =
+			error.error === 'Not a participant'
+				? '試合参加者のみ投票できます。'
+				: error.error === 'Match is not in voting state'
+					? 'この試合は既に終了しています。'
+					: '投票に失敗しました。'
+
+		await interaction.reply({
+			content: message,
+			flags: MessageFlags.Ephemeral,
+		})
+		return
+	}
+
+	const data = (await response.json()) as {
+		success: boolean
+		blueVotes: number
+		redVotes: number
+	}
+
+	// 6票以上で確定チェック
+	const VOTES_REQUIRED = 6
+	if (data.blueVotes >= VOTES_REQUIRED || data.redVotes >= VOTES_REQUIRED) {
+		// 試合確定
+		const confirmResponse = await apiClient.guild.match[':id'].confirm.$post({
+			param: { id: matchId },
+		})
+
+		if (!confirmResponse.ok) {
+			logger.error('試合確定失敗:', confirmResponse.status)
+			await interaction.reply({
+				content: '試合の確定に失敗しました。',
+				flags: MessageFlags.Ephemeral,
+			})
+			return
+		}
+
+		const confirmData = (await confirmResponse.json()) as {
+			success: boolean
+			winningTeam: 'blue' | 'red'
+			ratingChanges: Array<{
+				discordId: string
+				team: 'blue' | 'red'
+				ratingBefore: number
+				ratingAfter: number
+				change: number
+				rank: string
+			}>
+		}
+
+		// 結果Embed
+		const resultEmbed = createMatchResultEmbed(confirmData.winningTeam, confirmData.ratingChanges)
+
+		await interaction.update({
+			embeds: [resultEmbed],
+			components: [],
+		})
+	} else {
+		// 投票状況を更新
+		const matchResponse = await apiClient.guild.match[':id'].$get({
+			param: { id: matchId },
+		})
+
+		if (!matchResponse.ok) {
+			await interaction.reply({
+				content: `${vote === 'blue' ? '🔵 Blue' : '🔴 Red'}勝利に投票しました。`,
+				flags: MessageFlags.Ephemeral,
+			})
+			return
+		}
+
+		const matchData = (await matchResponse.json()) as {
+			match: {
+				teamAssignments: TeamAssignments
+				blueVotes: number
+				redVotes: number
+			}
+			votesRequired: number
+		}
+
+		const embed = createMatchEmbed(
+			matchData.match.teamAssignments,
+			matchData.match.blueVotes,
+			matchData.match.redVotes,
+			matchData.votesRequired,
+		)
+		const buttons = createVoteButtons(matchId)
+
+		await interaction.update({
+			embeds: [embed],
+			components: [buttons],
+		})
+	}
+}
+
+// 投票キャンセルハンドラー
+const handleVoteCancel = async (interaction: ButtonInteraction<CacheType>, matchId: string) => {
+	// 試合情報取得
+	const matchResponse = await apiClient.guild.match[':id'].$get({
+		param: { id: matchId },
+	})
+
+	if (!matchResponse.ok) {
+		await interaction.reply({
+			content: '試合情報の取得に失敗しました。',
+			flags: MessageFlags.Ephemeral,
+		})
+		return
+	}
+
+	const matchData = (await matchResponse.json()) as {
+		match: {
+			teamAssignments: TeamAssignments
+		}
+	}
+
+	// 参加者チェック
+	if (!matchData.match.teamAssignments[interaction.user.id]) {
+		await interaction.reply({
+			content: '試合参加者のみキャンセルできます。',
+			flags: MessageFlags.Ephemeral,
+		})
+		return
+	}
+
+	// 試合キャンセルAPI呼び出し
+	const cancelResponse = await apiClient.guild.match[':id'].$delete({
+		param: { id: matchId },
+	})
+
+	if (!cancelResponse.ok) {
+		const error = (await cancelResponse.json()) as { error?: string }
+		const message =
+			error.error === 'Match is not in voting state' ? 'この試合は既に終了しています。' : 'キャンセルに失敗しました。'
+
+		await interaction.reply({
+			content: message,
+			flags: MessageFlags.Ephemeral,
+		})
+		return
+	}
+
+	const embed = createMatchEmbed(matchData.match.teamAssignments, 0, 0, 6, 'cancelled')
 
 	await interaction.update({
 		embeds: [embed],
 		components: [],
 	})
 
-	const mentions = recruitData.participants.map((p) => `<@${p.discordId}>`).join(' ')
 	await interaction.followUp({
-		content: `🏆 ランク戦強制開始！ ${mentions}\n\n/team balance でチーム分けを行ってください。`,
+		content: '試合がキャンセルされました。',
 	})
 }

--- a/src/commands/recruit/shared.ts
+++ b/src/commands/recruit/shared.ts
@@ -6,7 +6,7 @@ import {
 	StringSelectMenuBuilder,
 	StringSelectMenuOptionBuilder,
 } from 'discord.js'
-import { colors } from '@/config'
+import { colors, emoji } from '@/config'
 
 export const CAPACITY = 10
 
@@ -273,4 +273,209 @@ export const createRoleSelectMenu = (recruitmentId: string, type: 'main' | 'sub'
 			.setPlaceholder(type === 'main' ? 'メインロールを選択' : 'サブロールを選択')
 			.addOptions(options),
 	)
+}
+
+// チーム振り分け用の型
+export type TeamAssignment = {
+	team: 'blue' | 'red'
+	role: LolRole
+	rating: number
+}
+
+export type TeamAssignments = Record<string, TeamAssignment>
+
+export type RatingInfo = {
+	discordId: string
+	rating: number
+	rank: string | null
+	isPlacement: boolean | null
+}
+
+// チーム振り分け結果表示用Embed
+export const createMatchEmbed = (
+	teamAssignments: TeamAssignments,
+	blueVotes: number,
+	redVotes: number,
+	votesRequired: number,
+	status: 'voting' | 'confirmed' | 'cancelled' = 'voting',
+) => {
+	const blueTeam = Object.entries(teamAssignments)
+		.filter(([, a]) => a.team === 'blue')
+		.map(([discordId, a]) => ({ discordId, ...a }))
+	const redTeam = Object.entries(teamAssignments)
+		.filter(([, a]) => a.team === 'red')
+		.map(([discordId, a]) => ({ discordId, ...a }))
+
+	const blueTotal = blueTeam.reduce((sum, p) => sum + p.rating, 0)
+	const redTotal = redTeam.reduce((sum, p) => sum + p.rating, 0)
+
+	const formatTeamMember = (p: { discordId: string; role: LolRole; rating: number }) => {
+		return `${ROLE_EMOJIS[p.role]} <@${p.discordId}> (${p.rating})`
+	}
+
+	const title =
+		status === 'voting'
+			? '🏆 ランク戦 - 勝敗投票'
+			: status === 'confirmed'
+				? '🏆 ランク戦 - 結果確定'
+				: '🏆 ランク戦 - キャンセル'
+
+	const color = status === 'voting' ? colors.primary : status === 'confirmed' ? colors.success : colors.error
+
+	const embed = new EmbedBuilder().setTitle(title).setColor(color)
+
+	embed.addFields(
+		{
+			name: `🔵 Blue Team (${blueTotal})`,
+			value: blueTeam.map(formatTeamMember).join('\n') || 'なし',
+			inline: true,
+		},
+		{
+			name: `🔴 Red Team (${redTotal})`,
+			value: redTeam.map(formatTeamMember).join('\n') || 'なし',
+			inline: true,
+		},
+	)
+
+	if (status === 'voting') {
+		embed.addFields({
+			name: '投票状況',
+			value: `🔵 Blue勝利: ${blueVotes}票 / 🔴 Red勝利: ${redVotes}票\n(${votesRequired}票で確定)`,
+			inline: false,
+		})
+	}
+
+	return embed
+}
+
+// 投票ボタン
+export const createVoteButtons = (matchId: string, disabled = false) => {
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder()
+			.setCustomId(`recruit:vote_blue:${matchId}`)
+			.setLabel('🔵 Blue勝利')
+			.setStyle(ButtonStyle.Primary)
+			.setDisabled(disabled),
+		new ButtonBuilder()
+			.setCustomId(`recruit:vote_red:${matchId}`)
+			.setLabel('🔴 Red勝利')
+			.setStyle(ButtonStyle.Danger)
+			.setDisabled(disabled),
+		new ButtonBuilder()
+			.setCustomId(`recruit:vote_cancel:${matchId}`)
+			.setLabel('キャンセル')
+			.setStyle(ButtonStyle.Secondary)
+			.setDisabled(disabled),
+	)
+}
+
+// 結果確定後のEmbed
+export const createMatchResultEmbed = (
+	winningTeam: 'blue' | 'red',
+	ratingChanges: Array<{
+		discordId: string
+		team: 'blue' | 'red'
+		ratingBefore: number
+		ratingAfter: number
+		change: number
+		rank: string
+	}>,
+) => {
+	const blueChanges = ratingChanges.filter((r) => r.team === 'blue')
+	const redChanges = ratingChanges.filter((r) => r.team === 'red')
+
+	const formatChange = (r: (typeof ratingChanges)[0]) => {
+		const changeStr = r.change >= 0 ? `+${r.change}` : `${r.change}`
+		const winLose = r.team === winningTeam ? '🏆' : ''
+		return `${winLose} <@${r.discordId}>: ${r.ratingBefore} → ${r.ratingAfter} (${changeStr})`
+	}
+
+	const embed = new EmbedBuilder()
+		.setTitle(`🏆 試合結果 - ${winningTeam === 'blue' ? '🔵 Blue' : '🔴 Red'} チーム勝利！`)
+		.setColor(winningTeam === 'blue' ? colors.blue : colors.red)
+		.addFields(
+			{
+				name: '🔵 Blue Team',
+				value: blueChanges.map(formatChange).join('\n') || 'なし',
+				inline: true,
+			},
+			{
+				name: '🔴 Red Team',
+				value: redChanges.map(formatChange).join('\n') || 'なし',
+				inline: true,
+			},
+		)
+
+	return embed
+}
+
+// Eloに基づくチームバランス関数
+export const balanceTeamsByElo = (
+	participants: Array<{ discordId: string; mainRole?: LolRole | null; subRole?: LolRole | null; rating: number }>,
+): TeamAssignments => {
+	// レーティング順でソート
+	const sorted = [...participants].sort((a, b) => b.rating - a.rating)
+
+	// スネークドラフト方式で分配
+	const blueTeam: typeof sorted = []
+	const redTeam: typeof sorted = []
+
+	sorted.forEach((p, i) => {
+		// 0,3,4,7,8 → Blue, 1,2,5,6,9 → Red (スネーク)
+		const round = Math.floor(i / 2)
+		const isBlue = round % 2 === 0 ? i % 2 === 0 : i % 2 !== 0
+		if (isBlue) {
+			blueTeam.push(p)
+		} else {
+			redTeam.push(p)
+		}
+	})
+
+	// ロールを割り当て
+	const assignRoles = (team: typeof sorted): Array<{ discordId: string; role: LolRole; rating: number }> => {
+		const assigned: Array<{ discordId: string; role: LolRole; rating: number }> = []
+		const usedRoles = new Set<LolRole>()
+
+		// まずメインロールで割り当て
+		for (const p of team) {
+			if (p.mainRole && !usedRoles.has(p.mainRole)) {
+				assigned.push({ discordId: p.discordId, role: p.mainRole, rating: p.rating })
+				usedRoles.add(p.mainRole)
+			}
+		}
+
+		// サブロールで割り当て
+		for (const p of team) {
+			if (!assigned.find((a) => a.discordId === p.discordId)) {
+				if (p.subRole && !usedRoles.has(p.subRole)) {
+					assigned.push({ discordId: p.discordId, role: p.subRole, rating: p.rating })
+					usedRoles.add(p.subRole)
+				}
+			}
+		}
+
+		// 残りは空いているロールを割り当て
+		const remainingRoles = LOL_ROLES.filter((r) => !usedRoles.has(r))
+		for (const p of team) {
+			if (!assigned.find((a) => a.discordId === p.discordId)) {
+				const role = remainingRoles.shift() || 'mid'
+				assigned.push({ discordId: p.discordId, role, rating: p.rating })
+			}
+		}
+
+		return assigned
+	}
+
+	const blueAssigned = assignRoles(blueTeam)
+	const redAssigned = assignRoles(redTeam)
+
+	const result: TeamAssignments = {}
+	for (const p of blueAssigned) {
+		result[p.discordId] = { team: 'blue', role: p.role, rating: p.rating }
+	}
+	for (const p of redAssigned) {
+		result[p.discordId] = { team: 'red', role: p.role, rating: p.rating }
+	}
+
+	return result
 }


### PR DESCRIPTION
## Summary
- ランク戦募集完了時の自動チーム分け（Eloバランス）
- 勝敗投票UI（Blue/Red投票ボタン）
- 6票以上で試合確定・レート更新
- `/rank server [@user]` - サーバー内ランク表示
- `/rank leaderboard [limit]` - サーバーランキング表示

## Dependencies
⚠️ **このPRはhexcuit/server#48 のマージ・公開後に動作します**

サーバーで追加された以下のAPIを使用:
- `POST /guild/match` - 試合作成
- `GET /guild/match/:id` - 試合取得
- `POST /guild/match/:id/vote` - 投票
- `POST /guild/match/:id/confirm` - 試合確定
- `DELETE /guild/match/:id` - 試合キャンセル

## Pre-merge Checklist
- [ ] server#48 がマージされていること
- [ ] `@hexcuit/server` が npm に公開されていること
- [ ] `bun add @hexcuit/server@latest` で更新すること

## Test plan
- [ ] ランク戦募集が10人で自動チーム分けされることを確認
- [ ] 投票ボタンが正常に動作することを確認
- [ ] 6票以上で試合確定されることを確認
- [ ] `/rank server` でランク情報が表示されることを確認
- [ ] `/rank leaderboard` でランキングが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)