### PR TITLE
fix: changeset のパッケージ名を修正

### DIFF
--- a/.changeset/ranked-draw.md
+++ b/.changeset/ranked-draw.md
@@ -1,5 +1,5 @@
 ---
-"discord-bot": minor
+"@hexcuit/discord-bot": minor
 ---
 
 feat: ランク戦に引き分け機能を追加


### PR DESCRIPTION
## Summary
- `ranked-draw.md` のパッケージ名を `discord-bot` → `@hexcuit/discord-bot` に修正

## Reason
changeset version コマンドで「package discord-bot which is not in the workspace」エラーが発生していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)