### PR TITLE
ci: add manual deploy workflow and .env setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      update_env:
+        description: 'Update .env file from secrets'
+        type: boolean
+        default: true
+      restart_only:
+        description: 'Restart only (skip docker pull)'
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    name: Deploy to VPS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Copy docker-compose.yml to VPS
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          source: "docker-compose.yml"
+          target: "/opt/hexcuit-discord-bot/"
+
+      - name: Create .env file on VPS
+        if: ${{ inputs.update_env }}
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          script: |
+            cat > /opt/hexcuit-discord-bot/.env << 'EOF'
+            DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }}
+            DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}
+            API_BASE_URL=${{ secrets.API_BASE_URL }}
+            API_KEY=${{ secrets.API_KEY }}
+            DISCORD_LOG_WEBHOOK_URL=${{ secrets.DISCORD_LOG_WEBHOOK_URL }}
+            EOF
+
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          script: |
+            cd /opt/hexcuit-discord-bot
+            if [ "${{ inputs.restart_only }}" = "true" ]; then
+              docker compose restart
+            else
+              docker compose pull
+              docker compose up -d
+            fi
+            docker image prune -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,23 @@ jobs:
           source: "docker-compose.yml"
           target: "/opt/hexcuit-discord-bot/"
 
+      - name: Create .env file on VPS
+        if: steps.version_check.outputs.version_changed == 'true'
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          script: |
+            cat > /opt/hexcuit-discord-bot/.env << 'EOF'
+            DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }}
+            DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}
+            API_BASE_URL=${{ secrets.API_BASE_URL }}
+            API_KEY=${{ secrets.API_KEY }}
+            DISCORD_LOG_WEBHOOK_URL=${{ secrets.DISCORD_LOG_WEBHOOK_URL }}
+            EOF
+
       - name: Deploy to VPS
         if: steps.version_check.outputs.version_changed == 'true'
         uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4


### PR DESCRIPTION
## Summary
- 手動デプロイ用ワークフロー (`deploy.yml`) を追加
- リリースワークフローに `.env` ファイル作成ステップを追加

## Changes
- **deploy.yml (新規)**: `workflow_dispatch` による手動デプロイ
  - `.env` ファイルをシークレットから更新するオプション
  - 再起動のみ（docker pull をスキップ）オプション
- **release.yml**: バージョン変更時に VPS 上で `.env` ファイルを作成

## Test Plan
- [ ] Actions タブから deploy ワークフローを手動実行できることを確認
- [ ] リリース時に .env ファイルが正しく作成されることを確認

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established new deployment workflow with manual trigger options and flexible deployment modes, allowing restart-only or full pull-and-deploy operations.
  * Enhanced environment configuration management by improving secret variable handling across deployment pipelines.
  * Implemented automated Docker image cleanup following successful deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->