### PR TITLE
fix: shorten role selection button customId to fit Discord's 100 char limit

### DIFF
--- a/.changeset/calm-foxes-run.md
+++ b/.changeset/calm-foxes-run.md
@@ -1,0 +1,5 @@
+---
+'@hexcuit/discord-bot': patch
+---
+
+Fix role selection button customId exceeding Discord's 100 character limit by using shortened format

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@hexcuit/discord-bot",
       "dependencies": {
-        "@hexcuit/server": "0.12.1",
+        "@hexcuit/server": "0.12.2",
         "discord.js": "14.25.1",
       },
       "devDependencies": {
@@ -145,7 +145,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
-    "@hexcuit/server": ["@hexcuit/server@0.12.1", "", { "dependencies": { "@hono/zod-openapi": "1.2.0", "hono": "4.11.4" } }, "sha512-WL6fXF9MwEsnYTowLVNAxLbm1SDROou5eX64xJJrSyJSZntvrrWZdGK7JZb4aCBv40/WlMBJOV2M+18+FDJmOQ=="],
+    "@hexcuit/server": ["@hexcuit/server@0.12.2", "", { "dependencies": { "@hono/zod-openapi": "1.2.0", "hono": "4.11.4" } }, "sha512-lx77UfYBtYfXoYMyz8Y6BrlH0XtwEktPcSjCeOU34mZEJQlJSf7kt512c3b1N/YIdOeC8bGVVmH9SOG/f+o6BQ=="],
 
     "@hono/zod-openapi": ["@hono/zod-openapi@1.2.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.1.0", "@hono/zod-validator": "^0.7.6", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "^4.0.0" } }, "sha512-KDfHqv/Wy4elVseZXgokbHxeWuqBL+AZfqsOMpEihBMUsk/fJ+bLIi3Sf70JFVpt1Ihui8RasYrInozt7ZBDIA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"deploy:commands": "bun scripts/deploy-commands.ts"
 	},
 	"dependencies": {
-		"@hexcuit/server": "0.12.1",
+		"@hexcuit/server": "0.12.2",
 		"discord.js": "14.25.1"
 	},
 	"devDependencies": {

--- a/src/commands/queue/rank/embeds.ts
+++ b/src/commands/queue/rank/embeds.ts
@@ -86,11 +86,14 @@ export const createRoleButtons = (
 ) => {
 	const buttons = ROLE_PREFERENCES.map((role) => {
 		const isDisabled = type === 'sub' && role === selectedMainRole
-		// sub選択時はmainRoleもcustomIdに含める
+		// customIdは100文字制限があるため短縮形式を使用: q:sr:guildId:queueId:msgId:t:r[:mainR]
+		const t = type === 'main' ? 'm' : 's'
+		const r = role.slice(0, 3) // TOP, JUN, MID, BOT, SUP, FIL
+		const mainR = selectedMainRole?.slice(0, 3)
 		const customId =
 			type === 'sub'
-				? `queue:select_role:${guildId}:${queueId}:${originalMessageId}:${type}:${role}:${selectedMainRole}`
-				: `queue:select_role:${guildId}:${queueId}:${originalMessageId}:${type}:${role}`
+				? `q:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}:${mainR}`
+				: `q:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}`
 		return new ButtonBuilder()
 			.setCustomId(customId)
 			.setLabel(ROLE_LABELS[role])

--- a/src/commands/queue/shared/utils.ts
+++ b/src/commands/queue/shared/utils.ts
@@ -4,18 +4,47 @@ import { ROLE_EMOJI } from '@/config'
 
 import { ROLE_LABELS } from './constants'
 
+// 短縮ロール名を展開
+const expandRole = (short: string | undefined): RolePreference | undefined => {
+	if (!short) return undefined
+	const map: Record<string, RolePreference> = {
+		TOP: 'TOP',
+		JUN: 'JUNGLE',
+		MID: 'MIDDLE',
+		BOT: 'BOTTOM',
+		SUP: 'SUPPORT',
+		FIL: 'FILL',
+	}
+	return map[short] ?? (short as RolePreference)
+}
+
 export const parseCustomId = (customId: string) => {
 	const parts = customId.split(':')
+
+	// 短縮形式 (q:sr:...) かどうか判定
+	const isShortFormat = parts[0] === 'q'
+
+	// コマンドとアクションを展開
+	const command = isShortFormat && parts[0] === 'q' ? 'queue' : parts[0]
+	const action = isShortFormat && parts[1] === 'sr' ? 'select_role' : parts[1]
+
+	// ロールタイプを展開 (m -> main, s -> sub)
+	const roleType =
+		parts[5] === 'm' ? 'main' : parts[5] === 's' ? 'sub' : (parts[5] as 'main' | 'sub' | undefined)
+
+	// ロールを展開
+	const role = isShortFormat ? expandRole(parts[6]) : (parts[6] as RolePreference | undefined)
+	const mainRole = isShortFormat ? expandRole(parts[7]) : (parts[7] as RolePreference | undefined)
+
 	return {
-		command: parts[0],
-		action: parts[1],
+		command,
+		action,
 		guildId: parts[2],
 		queueId: parts[3],
 		originalMessageId: parts[4],
-		// ロール選択ボタン用の追加パラメータ
-		roleType: parts[5] as 'main' | 'sub' | undefined,
-		role: parts[6] as RolePreference | undefined,
-		mainRole: parts[7] as RolePreference | undefined, // sub選択時のみ
+		roleType,
+		role,
+		mainRole,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix role selection buttons failing due to customId exceeding Discord's 100 character limit

## Changes
- Shorten customId format from `queue:select_role:...` to `q:sr:...`
- Abbreviate role type (`main`/`sub` → `m`/`s`)
- Abbreviate role names to 3 chars (`JUNGLE` → `JUN`, `FILL` → `FIL`, etc.)
- Update `parseCustomId` to expand shortened format back to full values

## Test Plan
- [x] TypeScript type check passes
- [ ] Click "参加" button on ranked queue embed
- [ ] Verify main role selection buttons appear
- [ ] Select a main role and verify sub role selection appears
- [ ] Select sub role and verify queue join succeeds

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed role selection button formatting to comply with Discord's 100-character platform limit, ensuring reliable button functionality.

## Chores
* Updated internal server dependency to version 0.12.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->