### PR TITLE
fix: use 'queue' instead of 'q' in customId for proper command routing

### DIFF
--- a/.changeset/happy-birds-fly.md
+++ b/.changeset/happy-birds-fly.md
@@ -1,0 +1,5 @@
+---
+'@hexcuit/discord-bot': patch
+---
+
+Fix role selection button routing by using 'queue' instead of 'q' in customId

--- a/src/commands/queue/rank/embeds.ts
+++ b/src/commands/queue/rank/embeds.ts
@@ -86,14 +86,14 @@ export const createRoleButtons = (
 ) => {
 	const buttons = ROLE_PREFERENCES.map((role) => {
 		const isDisabled = type === 'sub' && role === selectedMainRole
-		// customIdは100文字制限があるため短縮形式を使用: q:sr:guildId:queueId:msgId:t:r[:mainR]
+		// customIdは100文字制限があるため短縮形式を使用: queue:sr:guildId:queueId:msgId:t:r[:mainR]
 		const t = type === 'main' ? 'm' : 's'
 		const r = role.slice(0, 3) // TOP, JUN, MID, BOT, SUP, FIL
 		const mainR = selectedMainRole?.slice(0, 3)
 		const customId =
 			type === 'sub'
-				? `q:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}:${mainR}`
-				: `q:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}`
+				? `queue:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}:${mainR}`
+				: `queue:sr:${guildId}:${queueId}:${originalMessageId}:${t}:${r}`
 		return new ButtonBuilder()
 			.setCustomId(customId)
 			.setLabel(ROLE_LABELS[role])

--- a/src/commands/queue/shared/utils.ts
+++ b/src/commands/queue/shared/utils.ts
@@ -21,12 +21,11 @@ const expandRole = (short: string | undefined): RolePreference | undefined => {
 export const parseCustomId = (customId: string) => {
 	const parts = customId.split(':')
 
-	// 短縮形式 (q:sr:...) かどうか判定
-	const isShortFormat = parts[0] === 'q'
+	// 短縮形式 (queue:sr:...) かどうか判定（action が 'sr' の場合）
+	const isShortFormat = parts[1] === 'sr'
 
-	// コマンドとアクションを展開
-	const command = isShortFormat && parts[0] === 'q' ? 'queue' : parts[0]
-	const action = isShortFormat && parts[1] === 'sr' ? 'select_role' : parts[1]
+	// アクションを展開
+	const action = isShortFormat ? 'select_role' : parts[1]
 
 	// ロールタイプを展開 (m -> main, s -> sub)
 	const roleType =
@@ -37,7 +36,7 @@ export const parseCustomId = (customId: string) => {
 	const mainRole = isShortFormat ? expandRole(parts[7]) : (parts[7] as RolePreference | undefined)
 
 	return {
-		command,
+		command: parts[0],
 		action,
 		guildId: parts[2],
 		queueId: parts[3],


### PR DESCRIPTION
## Summary
- Fix role selection buttons not responding due to command routing failure

## Problem
PR #71 used `q:sr:...` format for customId, but the button handler routes based on the first segment of customId to find registered commands. Since commands are registered as `queue` (not `q`), the handler couldn't find the command and silently failed.

## Solution
Changed format from `q:sr:...` to `queue:sr:...` which still fits within Discord's 100 char limit (~89 chars).

## Test Plan
- [ ] Click "参加" button on ranked queue embed
- [ ] Verify main role selection buttons appear
- [ ] Click any role button
- [ ] Verify sub role selection appears (or auto-join for FILL)

---
🤖 Generated with Claude Code